### PR TITLE
create a package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,21 @@
+var fs = require('fs');
+var join = require('path').join;
+
+exports.agent = {
+  js: require('./agent.js.json'),
+  css: require('./agent.css.json'),
+};
+
+exports.useragent = require('./agent.json');
+exports.normalize = require('./normalize.json');
+
+// map lookup for sources with aliases
+// source[name] = js string
+var source = exports.source = {};
+var sourceFolder = join(__dirname, 'source');
+
+fs.readdirSync(sourceFolder).forEach(function (filename) {
+  if (filename[0] === '.') return;
+
+  source[filename.replace(/\.js$/, '')] = fs.readFileSync(join(sourceFolder, filename), 'utf8');
+});

--- a/package.json
+++ b/package.json
@@ -1,8 +1,21 @@
 {
   "name": "polyfill",
+  "description": "A polyfill combinator",
   "version": "1.0.0",
-  "private": true,
-  "dependencies": {
+  "author": {
+    "name": "Jonathan Neal",
+    "email": "jonathantneal+github@gmail.com",
+    "url": "http://jonathantneal.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonathantneal/polyfill"
+  },
+  "bugs": {
+    "url": "https://github.com/jonathantneal/polyfill/issues"
+  },
+  "license": "CC0 1.0 Universal License",
+  "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.4"
   }


### PR DESCRIPTION
this PR creates a package.json so people can consume polyfill's .json and polyfills via node and npm. this will make it easier if we decide to add js logic to this repo as described in https://github.com/jonathantneal/polyfill/issues/31

so `polyfill.source['Array.isArray']` will give you the `Array.isArray` polyfill as a string. everything generally mimics the folder structure except i named `agent.json` as `polyfill.useragent`. you may want to rename stuff before you actually publish since i think that's a little confusing. 

however, the name `polyfill` is taken in the NPM repository. @marcello3d would you like to combine efforts and give @jonathantneal that name?

/cc @defunctzombie
