### PR TITLE
More robust matchMedia

### DIFF
--- a/source/Window.prototype.matchMedia.js
+++ b/source/Window.prototype.matchMedia.js
@@ -58,9 +58,9 @@
 		window = this,
 		list = new MediaQueryList();
 
-    if (0===arguments.length) {
-      throw new TypeError('Not enough arguments to window.matchMedia');
-    }
+		if (0===arguments.length) {
+			throw new TypeError('Not enough arguments to window.matchMedia');
+		}
 
 		list.media = String(query);
 		list.matches = evalQuery(window, list.media);


### PR DESCRIPTION
This change adds a few things to the matchMedia polyfill in response to frequent errors I experienced in IE 8/9:

```
>> matchMedia('tv')
  Expected ')'
  Object doesn't support this property or method

>> matchMedia('(min-resolution:144dpi)')
  Expected ')'
  Object doesn't support this property or method

// etc...
```

Specifically, using polyfill.io with [Leaflet](http://leafletjs.com) isn't working because it fails during feature detection.

I've tried to make calling matchMedia less prone to errors, and behave more like the native implementations on Firefox and Chrome:
- given an empty string, `matches == true`
- given zero arguments, it will throw a `TypeError`
- queries like `matchMedia('tv')` no longer fail with a syntax error
- queries like `matchMedia('(min-resolution:144dpi)')` no longer fail with a syntax error
- matches is always boolean

Let me know if there's anything I can change!
