### PR TITLE
Fixing wrong Function.prototype.bind behavior with Array arguments

### DIFF
--- a/source/Function.prototype.bind.js
+++ b/source/Function.prototype.bind.js
@@ -1,7 +1,14 @@
 // Function.prototype.bind
 Function.prototype.bind = function bind(scope) {
-	var callback = this, prepend = Array.prototype.slice.call(arguments, 1), Constructor = function () {}, bound = function () {
-		return callback.apply(this instanceof Constructor && scope ? this : scope, Array.prototype.concat.apply(prepend, arguments));
+	var
+	callback = this,
+	prepend = Array.prototype.slice.call(arguments, 1),
+	Constructor = function () {},
+	bound = function () {
+		return callback.apply(
+			this instanceof Constructor && scope ? this : scope,
+			prepend.concat(Array.prototype.slice.call(arguments, 0))
+		);
 	};
 
 	Constructor.prototype = bound.prototype = callback.prototype;


### PR DESCRIPTION
Arrays are beeing split into function arguments.

Test case:

``` javascript
var fn = function(a) { console.log(a); };
fn.bind(this)([1, 2, 3]);
```

Result: `1`
Expected result: `[1, 2, 3]`
