### PR TITLE
Date.toISOString() wrong result in some cases

### DIFF
--- a/source/Date.prototype.toISOString.js
+++ b/source/Date.prototype.toISOString.js
@@ -1,4 +1,4 @@
 // Date.prototype.toISOString
 Date.prototype.toISOString = function toISOString() {
-	return ((this.getUTCMonth() + 1) / 100 + this.toUTCString() + this * 1).replace(/..(..).+?(\d+)\D+(\d+).(\S+).*(...)/,'$3-$1-$2T$4.$5Z');
+	return ('' + (this.getUTCMonth() + 1) / 100 + this.getUTCDate() / 100 + this.toUTCString() + this * 1).replace(/..(..)..(..).+?(\d{4}).(\S+).*(...)/, '$3-$1-$2T$4.$5Z');
 };


### PR DESCRIPTION
Date.prototype.toISOString() used to return seconds in the milliseconds part if the latter were zero, and even a double if milliseconds were multiple of 10 or 100. Fixed it. Also removed the excessive `date` variable.
The second commit is a workaround for IE's < 11 dates without leading zeros (e.g. `'Fri, 7 Mar 2014 08:32:15 UTC'`).
